### PR TITLE
Feature: Add and read scores from API

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -14,22 +14,10 @@
         <article class="scoreboard">
             <div class="recent-heading-and-button">
                 <h2 class="recent-heading">Recent Scores</h2>
-                <button class="refresh-btn">Refresh</button>
+                <button class="refresh-button">Refresh</button>
             </div>
 
             <ul class="recent-scores-list">
-                <li class="recent-score">
-                    <span class="name">Name: </span>
-                    <span class="score">Score: </span>
-                </li>
-                <li class="recent-score">
-                    <span class="name">Name: </span>
-                    <span class="score">Score: </span>
-                </li>
-                <li class="recent-score">
-                    <span class="name">Name: </span>
-                    <span class="score">Score: </span>
-                </li>
                 <li class="recent-score">
                     <span class="name">Name: </span>
                     <span class="score">Score: </span>
@@ -46,6 +34,7 @@
               id="name"
               placeholder="Your name"
               class="form-input"
+              required
             />
             <input
               type="number"
@@ -53,8 +42,9 @@
               id="score"
               placeholder="Your score"
               class="form-input"
+              required
             />
-            <button type="submit" class="form-btn">Submit</button>
+            <button type="submit" class="submit-button">Submit</button>
           </form>
       </section>
     </main>

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,5 @@
 import './style.css';
+import refreshScores from './modules/utils.js';
+import './modules/rendering.js';
+
+refreshScores();

--- a/src/modules/api.js
+++ b/src/modules/api.js
@@ -1,5 +1,5 @@
 const url = 'https://us-central1-js-capstone-backend.cloudfunctions.net/api/';
-const id = 'e9Bi19uY3UWMPTgMd3lv';
+const id = '87OPAjtKd5z1TGXZZ9dx';
 
 const uploadScore = async (user, score) => {
   const response = await fetch(`${url}games/${id}/scores/`, {

--- a/src/modules/api.js
+++ b/src/modules/api.js
@@ -1,0 +1,22 @@
+const url = 'https://us-central1-js-capstone-backend.cloudfunctions.net/api/';
+const id = 'e9Bi19uY3UWMPTgMd3lv';
+
+const uploadScore = async (user, score) => {
+  const response = await fetch(`${url}games/${id}/scores/`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ user, score }),
+  });
+  const data = await response.json();
+  return data;
+};
+
+const getScores = async () => {
+  const response = await fetch(`${url}games/${id}/scores/`);
+  const data = await response.json();
+  return data;
+};
+
+export { uploadScore, getScores };

--- a/src/modules/rendering.js
+++ b/src/modules/rendering.js
@@ -1,0 +1,20 @@
+import { uploadScore } from './api.js';
+import refreshScores from './utils.js';
+
+const inputName = document.querySelector('input[name="name"]');
+const inputScore = document.querySelector('input[name="score"]');
+const submitButton = document.querySelector('.submit-button');
+const refreshButton = document.querySelector('.refresh-button');
+
+submitButton.addEventListener('click', async (e) => {
+  e.preventDefault();
+  const name = inputName.value;
+  const score = inputScore.value;
+  await uploadScore(name, score);
+  refreshScores();
+});
+
+refreshButton.addEventListener('click', (e) => {
+  e.preventDefault();
+  refreshScores();
+});

--- a/src/modules/utils.js
+++ b/src/modules/utils.js
@@ -1,0 +1,24 @@
+import { getScores } from './api.js';
+
+const recentScoresList = document.querySelector('.recent-scores-list');
+const inputName = document.querySelector('input[name="name"]');
+const inputScore = document.querySelector('input[name="score"]');
+
+const refreshScores = async () => {
+  const scores = await getScores();
+
+  recentScoresList.innerHTML = '';
+
+  scores.result.forEach((score) => {
+    const li = document.createElement('li');
+    li.classList.add('recent-score');
+    li.innerHTML = `${score.user}: ${score.score}`;
+    recentScoresList.appendChild(li);
+  });
+
+  // reset input fields
+  inputName.value = '';
+  inputScore.value = '';
+};
+
+export default refreshScores;


### PR DESCRIPTION
In this pull request, I added the feature that the user can add names and scores to the leaderboard and read all the other submissions too. The data is also neatly rendered on the webpage.